### PR TITLE
Fix feedback API endpoint and email response

### DIFF
--- a/index.html
+++ b/index.html
@@ -729,16 +729,19 @@
                         <tr>
                             <th>ID</th>
                             <th>Имя</th>
+                            <th>Фамилия</th>
+                            <th>Отчество</th>
                             <th>Email</th>
                             <th>Вопрос</th>
                             <th>Статус</th>
+                            <th>Ответ</th>
                             <th>Дата</th>
                             <th>Действия</th>
                         </tr>
                     </thead>
                     <tbody id="questions-list">
                         <tr>
-                            <td colspan="7" style="text-align: center;">Загрузка вопросов...</td>
+                            <td colspan="10" style="text-align: center;">Загрузка вопросов...</td>
                         </tr>
                     </tbody>
                 </table>

--- a/js/api.js
+++ b/js/api.js
@@ -150,6 +150,7 @@ function refreshData(endpoint) {
         case 'partners': typeof loadPartners === 'function' && loadPartners(); break;
         case 'polls': typeof loadPolls === 'function' && loadPolls(); break;
         case 'questions': typeof loadQuestions === 'function' && loadQuestions(); break;
+        case 'feedbacks': typeof loadQuestions === 'function' && loadQuestions(); break;
     }
     typeof loadSystemStats === 'function' && loadSystemStats();
 }


### PR DESCRIPTION
Update questions management to use `/api/feedbacks/` endpoint, display full user names, and enable email replies from the admin panel.

---
<a href="https://cursor.com/background-agent?bcId=bc-bf5a6e9a-6518-4440-9b9c-bf67944e358f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bf5a6e9a-6518-4440-9b9c-bf67944e358f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

